### PR TITLE
Fix NameError in setup.py on Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import sys
 
 if sys.version_info < (2,7):
     requires = ['argparse', ]
+else:
+    requires = []
 
 setup(
     name = "gnome-background-generator",


### PR DESCRIPTION
The PyPI package is broken as well.
